### PR TITLE
Add: 2021-11-14 뉴스클러스터링 2차 풀이 + 해결

### DIFF
--- a/일반/newsClustering.js
+++ b/일반/newsClustering.js
@@ -2,22 +2,28 @@
 // 링크: https://programmers.co.kr/learn/courses/30/lessons/17677?language=javascript
 
 function solution(str1, str2) {
-  const answer = 0;
-  const newStr1 = str1.toLowerCase().replace(/[^a-z]/gi, '');
-  const newStr2 = str2.toLowerCase().replace(/[^a-z]/gi, '');
+  let answer = 0;
+  const newStr1 = str1.toLowerCase();
+  const newStr2 = str2.toLowerCase();
+
   const arr1 = [];
   const arr2 = [];
   const dic1 = {};
   const dic2 = {};
-
+  const result = {};
+  //arr에 push 될 때, 공백 및 특수문자가 걸러짐
   for (let i = 0; i < newStr1.length - 1; i++) {
     const key = newStr1.slice(i, i + 2);
-    arr1.push(key);
+    key.match(/[^a-z]/gi) ? '' : arr1.push(key);
   }
   for (let i = 0; i < newStr2.length - 1; i++) {
     const key = newStr2.slice(i, i + 2);
-    arr2.push(key);
+    key.match(/[^a-z]/gi) ? '' : arr2.push(key);
   }
+
+  //둘 다 공집합일 경우 예외처리
+  if (!(arr1.length || arr2.length)) return 1 * 65536;
+
   arr1.forEach((word) => {
     dic1[word] = (dic1[word] || 0) + 1;
   });
@@ -25,6 +31,14 @@ function solution(str1, str2) {
     dic2[word] = (dic2[word] || 0) + 1;
   });
 
-  console.log(newStr1, arr1, dic1);
-  return answer;
+  for (let word of Object.keys(dic1)) {
+    if (word in dic2) {
+      //교집합의 개수를 구하는 중.
+      answer += Math.min(dic1[word], dic2[word]);
+    }
+  }
+  const jakard = parseInt(
+    (answer * 65536) / (arr1.length + arr2.length - answer)
+  );
+  return jakard;
 }


### PR DESCRIPTION
# Description
## 접근법
처음에는 str1과 str2 에 대해서 특수문자와 공백을 지운 상태에서 2 철자씩 끊어야 한다고 생각했습니다. 
하지만 몇 차례의 오류를 겪고 나니, str1과 str2상태에서 2철자씩 끊고, 이후에 공백과 특수문자를 검증하는 것이 올바른 접근법임을 깨달았습니다.

배열을 통해서 중복된 원소를 지닐 수 있게 하였고, 객체를 통해서 교집합의 개수를 구할 때 이미 교집합에 포함된 key를 다시 교집합에 추가할 수 없도록 하였습니다. 

A와 B의 합집합은 A의 크기 + B의 크기 - A와B의 교집합의 크기 임을 이용하여 answer을 구하였습니다. 

## 아쉬운 점
배열과 객체선언을 너무 많이 한 것 같습니다. 
이는 str1과 str2를 배열과 객체로 변환할 때 절차지향적으로 코드를 짰기 때문이라고 생각합니다.
제 로직을 개선할 수 있는 방법이 있다면 제안해주시면 감사하겠습니다.
