### PR TITLE
2022-01-06 그룹단어체커 문제풀이 완료

### DIFF
--- a/구현/BOJ_1316.js
+++ b/구현/BOJ_1316.js
@@ -1,11 +1,5 @@
 const fs = require('fs')
 const [n, ...arr] = fs.readFileSync('/dev/stdin').toString().trim().split(/\s+/)
-// 직접 예시를 만들어 테스트 해 보고자 한다면, 디렉토리에 input.txt 테스트 입력 파일 생성 후, 아래 주석의 코드를 활용하면 됩니다!
-// const [n, ...arr] = fs
-//   .readFileSync(__dirname + '/input.txt', { encoding: 'utf8', flag: 'r' })
-//   .toString()
-//   .trim()
-//   .split(/\s+/)
 
 const solution = (n, arr) => {
   let answer = 0
@@ -19,18 +13,13 @@ const solution = (n, arr) => {
 const checkGroup = (target) => {
   const hashMap = {}
   let compressedTarget = target[0]
+  hashMap[compressedTarget] = 1
   for (let i = 1; i < target.length; i++) {
     const currentCh = target[i]
     if (compressedTarget[compressedTarget.length - 1] === currentCh) continue
+    if (Object.keys(hashMap).includes(currentCh)) return false
+    hashMap[currentCh] = 1
     compressedTarget += currentCh
-  }
-  for (let ch of compressedTarget) {
-    //Set 자료구조를 사용해도 될 듯?
-    if (Object.keys(hashMap).includes(ch)) {
-      return false
-    } else {
-      hashMap[ch] = 1
-    }
   }
   return true
 }

--- a/구현/BOJ_1316.js
+++ b/구현/BOJ_1316.js
@@ -1,0 +1,38 @@
+const fs = require('fs')
+const [n, ...arr] = fs.readFileSync('/dev/stdin').toString().trim().split(/\s+/)
+// 직접 예시를 만들어 테스트 해 보고자 한다면, 디렉토리에 input.txt 테스트 입력 파일 생성 후, 아래 주석의 코드를 활용하면 됩니다!
+// const [n, ...arr] = fs
+//   .readFileSync(__dirname + '/input.txt', { encoding: 'utf8', flag: 'r' })
+//   .toString()
+//   .trim()
+//   .split(/\s+/)
+
+const solution = (n, arr) => {
+  let answer = 0
+  for (let i = 0; i < n; i++) {
+    const targetWord = arr[i]
+    checkGroup(targetWord) ? (answer += 1) : (answer += 0)
+  }
+  console.log(answer)
+}
+
+const checkGroup = (target) => {
+  const hashMap = {}
+  let compressedTarget = target[0]
+  for (let i = 1; i < target.length; i++) {
+    const currentCh = target[i]
+    if (compressedTarget[compressedTarget.length - 1] === currentCh) continue
+    compressedTarget += currentCh
+  }
+  for (let ch of compressedTarget) {
+    //Set 자료구조를 사용해도 될 듯?
+    if (Object.keys(hashMap).includes(ch)) {
+      return false
+    } else {
+      hashMap[ch] = 1
+    }
+  }
+  return true
+}
+
+solution(n, arr)

--- a/구현/input.txt
+++ b/구현/input.txt
@@ -1,0 +1,4 @@
+3
+happy
+new
+year


### PR DESCRIPTION
# 문제풀이 접근법
## 문제 링크 : https://www.acmicpc.net/problem/1316
결과적으로 문자열을 압축하고, 압축한 문자열에서 중복되는 철자가 있는 단어는 그룹단어가 아니게 되는 것입니다.

위와 같은 접근법을 기반으로 
- O(n)시간의 철자 순회로 문자열을 먼저 압축했으며
- 압축한 문자열을 O(n)시간의 철자별 순회로 중복여부를 체크했습니다.

## 코드 개선
- 두 번의 for 문 순회는 비효율적이라 생각하여, 중복여부 체크 로직을 압축 과정에 병합하였습니다. 
- 그렇지만, 실질적인 코드의 수행 시간에는 별 차이가 없었고 가독성만 해친 느낌입니다.