### PR TITLE
2022-01-07 하노이의 탑 문제풀이

### DIFF
--- a/재귀/BOJ_11729.js
+++ b/재귀/BOJ_11729.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const n = parseInt(fs.readFileSync('/dev/stdin').toString().trim())
+
+const solution = (n) => {
+  let count = 0
+  const answer = []
+  const moveHanoiTower = (n, from, rest, to) => {
+    if (!n) return
+    moveHanoiTower(n - 1, from, to, rest)
+    answer.push([from, to])
+    count++
+    moveHanoiTower(n - 1, rest, from, to)
+  }
+  moveHanoiTower(n, 1, 2, 3)
+  console.log(count)
+  return answer.map((step) => step.join(' ')).join('\n')
+}
+
+console.log(solution(n))


### PR DESCRIPTION
# 문제풀이 접근법
## 기존에 알고 있던 점화식에 대한 재귀적 구현을 이해하는 것이 핵심!
단순히 `f(n) = 2f(n-1)+1`이 아니라, 왜 이렇게 되는 것인지를 이해하는 것이 핵심이다. 도식을 통해서 이해해 봅시다.
![image](https://user-images.githubusercontent.com/44149596/148640675-adae1e13-b5db-41b9-89f7-43e657529a4f.png)
이렇게 우리가 원하는 결과를 얻기 위해서는 
- 1단계: n-1까지의 원판을 3이 아닌 2로 옮이는 작업
- 2단계: 맨 마지막 원판을 1에서 3으로 옮기는 작업
- 3단계: 2에 놓여 있던 n-1개의 원판을 3으로 옮기는 작업

이렇게 세 가지의 subTask들로 이루어져 있음을 알 수 있다. 

그렇다면 이 인사이트를 재귀 코드로 구현하기 위해서 우리는 무엇을 해야 할까? 
1. 재귀 부분의 베이스 케이스를 처리한다.
![image](https://user-images.githubusercontent.com/44149596/148640683-c648afc8-3375-4cec-bfae-61bd2838c50c.png)
결국 끝까지 가다보면, 이 함수는 바닥을 치게 되는 상황, 즉 n=0인 상황을 마주하게 된다. 재귀에서는 이 바닥 케이스 (base case)에 대한 처리를 통해서 더 이상의 재귀를 멈추고, 값을 리턴하게 된다.

2. 재귀 부분에서 확실하게 기록할 값을 파악한다.
이 재귀 코드를 도는 동안에 우리는 확실히 재귀 코드가 짚고 넘어가는 단계들에 대한 추적이 필요하다. 그렇다면 어떤 값이 추적이 될까? n=1일 때, 1단계와 3단계는 건너 뛰어지고, 가운데 작업만이 수행이 된다. 

그렇다, 가운데 작업이 실질적으로 재귀가 종료되며 해당 함수를 호출한 상위 함수로 리턴되는 값이다.
`answer`배열이 이 값을 추적한다. 가장 먼저 리턴되는 값은 가장 먼저 수행될 원판의 이동 행위와 동일하다.

그렇다면 함수에는 어떤 인자들이 들어가야 할까?
일댠, 수행횟수를 카운트할 인풋값, 원판의 출발지, 원판의 도착지, 그리고!!!! 출발지도 도착지도 아닌 나머지 도착지. 이렇게 4개의 값이 들어가야 할 것이다. 

## 팁
input 값을 1에서 차례대로 올려가면서 값을 찾아가다 보면 첫 번째 원판 이동에 규칙이 있는 것을 발견할 수 있다.

---
1(원판 1개일 때 이동 횟수)
1 3
---
3(원판 2개일 때 이동 횟수)
1 2
1 3
2 3
---
7(원판 3개일 때 이동 횟수)
1 3
1 2
3 2
1 3
2 1
2 3
1 3
---
15(원판 4개일 때 이동 횟수)
1 2
1 3
2 3
1 2
3 1
3 2
1 2
1 3
2 3
2 1
3 1
2 3
1 2
1 3
2 3
---
인풋값이 하나씩 증가할 때마다, 첫번째 원판의 이동 목적지가 1 3/ 1 2/ 1 3/1 2 와 같이 진동한다는 점이다.

그 이유는 인풋값부터 거꾸로 상황을 생각해보면 자연스레 납득이 간다.
인풋값이 3 일때는 이전의 2개의 더 작은 원판이 2 번째 막대기에 순서에 맞게 걸려 있어야 하지만, 
인풋값이 4일때는 이전의 3개의 작은 원판을 2번째 막대기에 걸어 두어야 하기에, 그러기 위해서 2개의 원판은 3번째 막대기에 걸려있어야 하는 것이다!

마치 "내가 그럴줄 알고 이렇게 했지~라고 할 줄 알고 저렇게 했지~라고 할 줄 알고....." 끊임없는 뇌절 드립과 같은 것이라고 이해를 했다.

결론은 첫 원판의 이동은 반드시 1 3 인 것은 아니다!
