### PR TITLE
2022-01-14: 부등호 문제 해결

### DIFF
--- a/완전탐색/BOJ_2529.js
+++ b/완전탐색/BOJ_2529.js
@@ -20,9 +20,9 @@ const solution = (k, arr) => {
     }
     dequeuePointer += 1
   }
-  const answer = queue.slice(dequeuePointer)
-  console.log(answer[answer.length - 1])
-  console.log(answer[0])
+
+  console.log(queue[queue.length - 1])
+  console.log(queue[dequeuePointer])
 }
 
 solution(k, arr)

--- a/완전탐색/BOJ_2529.js
+++ b/완전탐색/BOJ_2529.js
@@ -1,0 +1,28 @@
+const input = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n')
+const k = parseInt(input[0])
+const arr = input[1].split(' ')
+
+const solution = (k, arr) => {
+  const queue = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+  let dequeuePointer = 0
+  while (queue[dequeuePointer].length < k + 1) {
+    const dequeued = queue[dequeuePointer]
+    for (let newNum = 0; newNum < 10; newNum++) {
+      if (!dequeued.includes('' + newNum)) {
+        const comparison =
+          arr[dequeued.length - 1] === '>'
+            ? dequeued[dequeued.length - 1] > newNum
+            : dequeued[dequeued.length - 1] < newNum
+        if (comparison) {
+          queue.push(dequeued + newNum)
+        }
+      }
+    }
+    dequeuePointer += 1
+  }
+  const answer = queue.slice(dequeuePointer)
+  console.log(answer[answer.length - 1])
+  console.log(answer[0])
+}
+
+solution(k, arr)


### PR DESCRIPTION
# 문제: [부등호](https://www.acmicpc.net/problem/2529)
## 문제풀이 접근법
큐를 통한 완전탐색을 통해 문제풀이를 진행하였습니다.

여기서 핵심은 큐를 shift()를 통해 길이를 줄이는 것이 아닌, 포인터값을 이용하여 dequeue할 위치를 기억해 두는 것입니다.

매 회차마다 dequeue를 시행하고, dequeue를 한 수의 가장 마지막 수와 새로 들어올 수를 비교하여 검증합니다. 이 때, 사용되지 않은 수임을 확인하기 위해 includes 함수를 사용하였습니다.

검증을 통과하면 새로운 수를 추가하여 enqueue합니다.
for 문을 오름차순으로 진행했기 때문에, 결과도 오름차순으로 정렬되어 있습니다. 

따라서 queue를 dequeuePointer부터 자른 queue의 맨 끝과 맨 처음 수를 리턴하면 정답입니다.

## 구현 시 어려웠던 점
'어떻게 단계별로 완전탐색을 진행해야 하는가?'를 결정하는 것이 어려웠습니다.
처음에는 재귀로 접근했다가 문제해결의 실마리를 찾지 못하고 헤맸습니다.

## 깨달음
BFS와 비슷하게, 큐를 통해서 완전탐색을 진행할 수 있음을 깨달았습니다.