### PR TITLE
2022-01-18: 블랙잭 문제해결

### DIFF
--- a/완전탐색/BOJ_2798.js
+++ b/완전탐색/BOJ_2798.js
@@ -1,0 +1,24 @@
+const [[N, M], cards] = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+  .map((i) => i.split(' ').map((j) => +j))
+
+const solution = (N, M, cards) => {
+  let closestSum = 0
+  for (let count = 0; count < Math.pow(2, cards.length); count++) {
+    let cardCounter = 0
+    let tempSum = 0
+    for (let j = 0; j < cards.length; j++) {
+      if (count & (1 << j)) {
+        tempSum += cards[j]
+        cardCounter++
+      }
+    }
+    if (cardCounter === 3 && tempSum > closestSum && tempSum < M) closestSum = tempSum
+  }
+  return closestSum
+}
+
+console.log(solution(N, M, cards))

--- a/완전탐색/BOJ_2798.js
+++ b/완전탐색/BOJ_2798.js
@@ -7,16 +7,14 @@ const [[N, M], cards] = require('fs')
 
 const solution = (N, M, cards) => {
   let closestSum = 0
-  for (let count = 0; count < Math.pow(2, cards.length); count++) {
-    let cardCounter = 0
-    let tempSum = 0
-    for (let j = 0; j < cards.length; j++) {
-      if (count & (1 << j)) {
-        tempSum += cards[j]
-        cardCounter++
+  const length = cards.length
+  for (let first = 0; first < length - 2; first++) {
+    for (let second = first + 1; second < length - 1; second++) {
+      for (let third = second + 1; third < length; third++) {
+        const tempSum = cards[first] + cards[second] + cards[third]
+        if (tempSum > closestSum && tempSum <= M) closestSum = tempSum
       }
     }
-    if (cardCounter === 3 && tempSum > closestSum && tempSum < M) closestSum = tempSum
   }
   return closestSum
 }


### PR DESCRIPTION
# 문제: [블랙잭](https://www.acmicpc.net/problem/2798)
## 문제풀이 접근법
3중 for 문을 통한 완전탐색으로 문제를 해결했습니다. 

## 구현 시 어려웠던 점
### 1차 문제 풀이 (시간 초과)
N개의 카드 중, 3개를 선택하는 방식이기에, 비트마스킹으로 접근했습니다. 하지만 N의 최대 입력 크기가 100이라는 점을 간과하여 시간초과가 발생했습니다. 

비트마스킹은 2의 N제곱 만큼의 순회를 하기에, 이 문제에서는 2의 100제곱의 순회를 진행하게 되고, 이는 주어진 1초의 수행시간을 지킬 수 없음을 의미합니다.

### 2차 문제 풀이 (해결)

따라서 최악의 경우 10의 6제곱인 백만 번의 순회를 하는 3중 for 문이 더 적절하다는 깨달음을 얻었습니다.

## 깨달음
입력의 크기를 고려하여 비트마스킹을 사용할지 여부를 결정해야 한다!
