### PR TITLE
2022-01-25 민식어 문제해결

### DIFF
--- a/정렬/BOJ_1599.js
+++ b/정렬/BOJ_1599.js
@@ -1,0 +1,14 @@
+const input = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+
+const N = input.shift()
+const arr = input.map((s) => s.replaceAll('ng', 'nz').replaceAll('k', 'c'))
+arr.sort()
+arr
+  .map((s) => s.replaceAll('nz', 'ng').replaceAll('c', 'k'))
+  .forEach((s) => {
+    console.log(s)
+  })


### PR DESCRIPTION
# 문제: [민식어](https://www.acmicpc.net/problem/1599)
## 문제풀이 접근법
알파벳 순서에 맞는, 민식어에서 사용되지 않는 알파벳으로 치환 후 문자열을 정렬합니다.

민식어의 'k'는 'c'로, 'ng'는 'nz'로 치환 후 정렬하였습니다.

이후 원래 민식어 알파벳으로 복구해주었습니다. 


## 구현 시 어려웠던 점
'ng'에 대한 처리를 생각하는 것이 어려웠습니다.
n과 o 사이에 있다는 문제의 설명에 매몰되어 버리면 ng 처리가 힘들어지는 것 같습니다.
'ny' 와 'ng' 가 존재할 때, 정렬 상 'ng'가 뒤에 와야 함을 깨닫고, 'ng'를 'nz'로 치환하여 사용해야겠다는 생각이 들었습니다. 

## 깨달음
문제 설명은 때로는 함정이 될 수도 있다!


