### PR TITLE
Add: 2022-02-02 동물원 문제해결

### DIFF
--- a/동적계획법/BOJ_1309.js
+++ b/동적계획법/BOJ_1309.js
@@ -1,0 +1,18 @@
+const input =
+  require('fs')
+    .readFileSync(__dirname + '/test.txt')
+    .toString()
+    .trim() * 1
+
+const solution = (n) => {
+  const arr = new Array(n + 1)
+  arr[0] = 0
+  arr[1] = 3
+  arr[2] = 7
+  for (let i = 3; i <= n; i++) {
+    arr[i] = (2 * arr[i - 1] + arr[i - 2]) % 9901
+  }
+  return arr[n]
+}
+
+console.log(solution(input))


### PR DESCRIPTION
# 문제: [동물원](https://www.acmicpc.net/problem/1309)
## 문제풀이 접근법
N 번째까지 호랑이를 넣을 수 있는 경우의 수는 N-1번째 줄에 호랑이가 있는 경우와  N-1번째 줄에 호랑이가 없는 경우(즉, N-2번째까지의 경우의 수)를 고려해야 한다. 

N 번째 좌측에 호랑이를 넣고자 한다면, N-1 번째 줄의 우측까지 호랑이를 넣는 경우 + N-1번째 줄을 비우는 경우
N 번째 우측에 호랑이를 넣고자 한다면, N-1 번째 줄의 좌측까지 호랑이를 넣는 경우 + N-1번째 줄을 비우는 경우
N 번째 를 비우고자 한다면, N-1번째 줄의 우측까지 호랑이를 넣는 경우, N-1번째 줄의 좌측까지 호랑이를 넣는 경우 + N-1번째 줄을 비우는 경우

이다. 

그러면 결국 N 번째의 경우의 수는 `2* ( N-1번째 경우의 수 ) + N-1번째 줄을 비우는 경우의 수`이다.
그런데 N-1번째 줄을 비우는 경우의 수는 N-2번째의 전체 경우의 수이다.


## 구현 시 어려웠던 점
규칙 찾기

## 깨달음
점화식적으로 생각을 잘 해보자!