### PR TITLE
Add: 2022-02-09 잃어버린 괄호 문제해결

### DIFF
--- a/그리디/BOJ_1541.js
+++ b/그리디/BOJ_1541.js
@@ -1,0 +1,28 @@
+const input = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split(/([+  -])/g)
+
+const solution = () => {
+  let sum = 0
+  let minus = 0
+  let currentOperator = 1
+  for (const element of input) {
+    if (element === '+') {
+      continue
+    } else if (element === '-') {
+      if (currentOperator === -1) {
+        sum -= minus
+        minus = 0
+      }
+      currentOperator = -1
+      continue
+    } else {
+      const num = element * 1
+      currentOperator === -1 ? (minus += num) : (sum += num)
+    }
+  }
+  console.log(sum - minus)
+}
+solution()

--- a/그리디/BOJ_1541.js
+++ b/그리디/BOJ_1541.js
@@ -1,5 +1,5 @@
 const input = require('fs')
-  .readFileSync(__dirname + '/test.txt')
+  .readFileSync('/dev/stdin')
   .toString()
   .trim()
   .split(/([+  -])/g)
@@ -15,9 +15,9 @@ const solution = () => {
       if (currentOperator === -1) {
         sum -= minus
         minus = 0
+        continue
       }
       currentOperator = -1
-      continue
     } else {
       const num = element * 1
       currentOperator === -1 ? (minus += num) : (sum += num)


### PR DESCRIPTION
# 문제: [잃어버린 괄호](https://www.acmicpc.net/problem/1541)
## 문제풀이 접근법
숫자의 합을 최대한 줄이기 위해서는 '-'연산자부터 다음 '-'연산자가 나올 때까지의 수를 다 더한 후(B), 임시 합(A)에서 빼주는 작업을 진행하면 된다.

인덱스를 순차적으로 순회하며 A-B 를 계속 갱신해주며 진행하면 된다.

## 구현 시 어려웠던 점
연산자에 대한 처리가 어려웠다. 입력값을 문자열로 받고 나서 정규식으로 연산자와 숫자를 분리해주는 작업을 진행했는데, 더 효율적인 방법이 있을지 궁금하다. 

## 깨달음
그리디 문제를 풀 때는 '컴퓨터는 미래를 모른다'는 점을 상기하며 풀이를 진행해야겠다