### PR TITLE
Add: 2022-02-13 조이스틱  문제 해결 (제출 성공)

### DIFF
--- a/그리디/PG_조이스틱.js
+++ b/그리디/PG_조이스틱.js
@@ -1,0 +1,52 @@
+//https://programmers.co.kr/learn/courses/30/lessons/42860
+function solution(name) {
+  let answer = 0
+  const result = []
+  let start = new Array(name.length).fill('A')
+
+  const chCodeArr = name
+    .split('')
+    .map((ch) => ch.charCodeAt(0) - 65)
+    .map((chCode) => Math.min(chCode, 26 - chCode))
+
+  const findClosestNum = (currentIndex) => {
+    //currentIndex로부터 A가 아닌 가장 가까운 문자를 지닌 인덱스 찾기-< A는 지나쳐도 되니까.
+    let distance = 1
+    let leftIndex = currentIndex
+    let rightIndex = currentIndex
+    let closestNextIndex = name.length + 1
+    while (distance < name.length) {
+      leftIndex = (currentIndex - distance + name.length) % name.length
+      rightIndex = (currentIndex + distance) % name.length
+      if (name[rightIndex] !== start[rightIndex] && name[leftIndex] !== start[leftIndex]) {
+        closestNextIndex = rightIndex
+        return { closestNextIndex: closestNextIndex, distance: distance }
+      } else if (name[rightIndex] === start[rightIndex] && name[leftIndex] !== start[leftIndex]) {
+        closestNextIndex = Math.min(leftIndex, closestNextIndex)
+        return { closestNextIndex: closestNextIndex, distance: distance }
+      } else if (name[rightIndex] !== start[rightIndex] && name[leftIndex] === start[leftIndex]) {
+        closestNextIndex = Math.min(rightIndex, closestNextIndex)
+        return { closestNextIndex: closestNextIndex, distance: distance }
+      } else {
+        distance++
+      }
+    }
+    return { closestNextIndex: name.length, distance: name.length }
+  }
+  for (let nextIndex = 0; nextIndex < name.length; nextIndex++) {
+    while (start.join('') !== name) {
+      answer += chCodeArr[nextIndex]
+      start[nextIndex] = name[nextIndex]
+      const next = findClosestNum(nextIndex)
+      if (next.closestNextIndex === name.length) return answer
+      nextIndex = next.closestNextIndex
+      answer += next.distance
+    }
+    result.push(answer)
+    answer = 0
+  }
+  return result
+}
+
+console.log(solution('BAJAAAAAAZ'))
+console.log(solution('BBBBAAAAABA'))

--- a/그리디/PG_조이스틱.js
+++ b/그리디/PG_조이스틱.js
@@ -11,24 +11,6 @@ function solution(name) {
     return 0
   }
 
-  //순방향 (우측): 0번 인덱스에서 가장 먼 A가아닌 철자의 인덱스
-  let toRight = upDown
-  for (let i = name.length - 1; i >= 0; i--) {
-    if (charCodeArr[i] !== 0) {
-      toRight += i
-      break
-    }
-  }
-
-  //역방향 (좌측): 0번 인덱스에서 우측으로 가장 가까운 A가 아닌 철자의 인덱스까지 역방향 거리
-  let toLeft = upDown
-  for (let i = 0; i < name.length; i++) {
-    if (charCodeArr[i] !== 0) {
-      toLeft += name.length - i
-      break
-    }
-  }
-
   let toRightLeft = name.length - 1
   let toLeftRight = name.length - 1
   //순->역 : 0번 인덱스부터 시작하여 차례대로 가장 작은 순->역 거리를 구한다.
@@ -54,5 +36,5 @@ function solution(name) {
   toRightLeft += upDown
   toLeftRight += upDown
 
-  return Math.min(toRight, toLeft, toRightLeft, toLeftRight)
+  return Math.min(toRightLeft, toLeftRight)
 }

--- a/그리디/PG_조이스틱.js
+++ b/그리디/PG_조이스틱.js
@@ -1,52 +1,58 @@
-//https://programmers.co.kr/learn/courses/30/lessons/42860
 function solution(name) {
-  let answer = 0
-  const result = []
-  let start = new Array(name.length).fill('A')
+  const answer = 0
+  //상하 움직임 계산
+  const charCodeArr = name.split('').map((ch) => {
+    const charCode = ch.charCodeAt(0) - 65
+    return Math.min(charCode, 26 - charCode)
+  })
+  const upDown = charCodeArr.reduce((a, b) => a + b, 0)
+  //모두A라면 그냥 끝내면 됨
+  if (charCodeArr.reduce((a, b) => a + b, 0) === 0) {
+    return 0
+  }
 
-  const chCodeArr = name
-    .split('')
-    .map((ch) => ch.charCodeAt(0) - 65)
-    .map((chCode) => Math.min(chCode, 26 - chCode))
+  //순방향 (우측): 0번 인덱스에서 가장 먼 A가아닌 철자의 인덱스
+  let toRight = upDown
+  for (let i = name.length - 1; i >= 0; i--) {
+    if (charCodeArr[i] !== 0) {
+      toRight += i
+      break
+    }
+  }
 
-  const findClosestNum = (currentIndex) => {
-    //currentIndex로부터 A가 아닌 가장 가까운 문자를 지닌 인덱스 찾기-< A는 지나쳐도 되니까.
-    let distance = 1
-    let leftIndex = currentIndex
-    let rightIndex = currentIndex
-    let closestNextIndex = name.length + 1
-    while (distance < name.length) {
-      leftIndex = (currentIndex - distance + name.length) % name.length
-      rightIndex = (currentIndex + distance) % name.length
-      if (name[rightIndex] !== start[rightIndex] && name[leftIndex] !== start[leftIndex]) {
-        closestNextIndex = rightIndex
-        return { closestNextIndex: closestNextIndex, distance: distance }
-      } else if (name[rightIndex] === start[rightIndex] && name[leftIndex] !== start[leftIndex]) {
-        closestNextIndex = Math.min(leftIndex, closestNextIndex)
-        return { closestNextIndex: closestNextIndex, distance: distance }
-      } else if (name[rightIndex] !== start[rightIndex] && name[leftIndex] === start[leftIndex]) {
-        closestNextIndex = Math.min(rightIndex, closestNextIndex)
-        return { closestNextIndex: closestNextIndex, distance: distance }
-      } else {
-        distance++
+  //역방향 (좌측): 0번 인덱스에서 우측으로 가장 가까운 A가 아닌 철자의 인덱스까지 역방향 거리
+  let toLeft = upDown
+  for (let i = 0; i < name.length; i++) {
+    if (charCodeArr[i] !== 0) {
+      toLeft += name.length - i
+      break
+    }
+  }
+
+  let toRightLeft = name.length - 1
+  let toLeftRight = name.length - 1
+  //순->역 : 0번 인덱스부터 시작하여 차례대로 가장 작은 순->역 거리를 구한다.
+  //역->순 : 0번 인덱스부터 시작하여 차례대로 가장 작은 순->역 거리를 구한다.
+  //순->역의 거리 : 인덱스까지의 거리 + 해당 인덱스에서 우측으로 가장 가까운 A가 아닌 철자의 인덱스까지 역방향 거리 = 2 * 인덱스 + 역방향 거리
+  //역->순의 거리 : 인덱스까지의 거리 + 최 우측부터 (해당 인덱스에서 우측으로 가장 가까운 A가 아닌 철자의 인덱스) 까지의 거리 * 2 = 인덱스 + 역방향 거리 * 2
+  for (let i = 0; i < name.length; i++) {
+    //가장 가까운 오른쪽 찾기
+    let tempToRightLeft = 0
+    let tempToLeftRight = 0
+    for (let j = i + 1; j < name.length; j++) {
+      if (charCodeArr[j] !== 0) {
+        tempToRightLeft += i + name.length - j
+        tempToLeftRight += 2 * (name.length - j)
+        break
       }
     }
-    return { closestNextIndex: name.length, distance: name.length }
+    tempToRightLeft += i
+    tempToLeftRight += i
+    toRightLeft = Math.min(toRightLeft, tempToRightLeft)
+    toLeftRight = Math.min(toLeftRight, tempToLeftRight)
   }
-  for (let nextIndex = 0; nextIndex < name.length; nextIndex++) {
-    while (start.join('') !== name) {
-      answer += chCodeArr[nextIndex]
-      start[nextIndex] = name[nextIndex]
-      const next = findClosestNum(nextIndex)
-      if (next.closestNextIndex === name.length) return answer
-      nextIndex = next.closestNextIndex
-      answer += next.distance
-    }
-    result.push(answer)
-    answer = 0
-  }
-  return result
-}
+  toRightLeft += upDown
+  toLeftRight += upDown
 
-console.log(solution('BAJAAAAAAZ'))
-console.log(solution('BBBBAAAAABA'))
+  return Math.min(toRight, toLeft, toRightLeft, toLeftRight)
+}


### PR DESCRIPTION
# 문제: [조이스틱](https://programmers.co.kr/learn/courses/30/lessons/42860?language=javascript#)
## 문제풀이 접근법
인덱스를 순회하며 인덱스의 우측으로 가장 가까운 A가 아닌 철자까지의 거리를 비교, 갱신해가는 방식입니다.

### 1단계: 상하 최적 움직임 계산
알파벳이 총 26개이고, N 이 그 중간인 13입니다. 13을 넘어가면 Z부터 접근하는 것이 빠르기에,

`Math.min(26-알파벳 아스키값 - 65, 알파벳 아스키값 -65)`으로 계산했습니다. 65를 뺀 이유는 A의 아스키값이 65이기 때문입니다.


### 2단계: 좌우 최적 움직임 파악
인덱스를 순회할 때, 인덱스가 의미하는 바는, 이 숫자가 우측이동의 최대값이라는 것입니다.
이 규칙을 준수하면서 이동하는 최적의 경우(최소이동거리)는 두 가지 케이스입니다.

1. 인덱스까지 우측 이동한 후, 인덱스의 우측으로 가장 가까운 A가 아닌 철자(`마지막 수`라 칭하겠습니다) 까지 좌측이동
이 케이스가 선택되는 테스트케이스는 "BAAABAA"일 것입니다. 
이 경우, 0번 인덱스 순회 시, 0번 인덱스는 이동이 없으니(우측 이동 0) 바로 좌측으로 이동하여 4번 인덱스의 B에 접근하는 경우가 최적입니다.

2. `마지막 수`까지 좌측이동한 후, 인덱스까지 우측 이동하는 경우입니다.
이 케이스가 선택되는 테스트케이스는 "BBBBAAABB"입니다. 
이 경우, 3번 인덱스까지 우측이동 후, 7번 인덱스까지 좌측이동을 하게 되면, 최적값이 나오지 않습니다. 
오히려 7번인덱스까지 좌측이동을 한 후, 4번 인덱스까지 우측이동을 하는 경우가 최적값입니다.

이 케이스를 고려하지 않으면 13번 케이스를 통과하지 못합니다.

### 3단계: 좌우 최적 움직임 계산
2단계의 1번 케이스는 2*인덱스 + (문자열의 길이)-(인덱스 기준 우측 가장 가까운 A가 아닌 철자의 인덱스),
2단계의 2번 케이스는 인덱스 + 2*{(문자열의 길이)-(인덱스 기준 우측 가장 가까운 A가 아닌 철자의 인덱스)}
로 구현할 수 있습니다.

### 4단계: 순회하며 최소값 파악
 각 인덱스를 순회하며, 각각의 경우에 나올 수 있는 최소값을 얻어냅니다.

## 구현 시 어려웠던 점

우측이동 후 좌측이동 케이스가 최적값인 테스트 케이스를 생각하지 못하였던 점

## 깨달음

케이스 분류를 잘 해야겠습니다.
알고리즘 문제는 분류하고 규격화 할 수 있는 문제들이라는 것을 꼭 명심하겠습니다.

이 문제가 그리디인 이유를 생각해 보았습니다.
어느 지점을 기준으로 삼는 것이 최적 지점인지는 한 번에 알 수 없기에, 각 지점을 기준으로 삼아 각 지점의 최적값을 구하고, 이후 전체의 최적값을 구한다는 점에서 그리디인 것 같습니다.

방향 전환은 최대 1번이라는 것(그 이상이 되면 최적값을 넘어서기에), 0번째 인덱스와 마지막 인덱스의 최적값을 구할 때는, 실질적으로 방향전환이 없는 역방향, 순방향 케이스라는 점을 깨달은 후에야, 구현을 제대로 할 수 있었습니다.







