### PR TITLE
2022-02-14 숨바꼭질 문제해결

### DIFF
--- a/DFSBFS/BOJ_1697.js
+++ b/DFSBFS/BOJ_1697.js
@@ -1,0 +1,22 @@
+const [N, K] = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split(' ')
+  .map(Number)
+
+const solution = (n, k) => {
+  let pointer = 0
+  const queue = []
+  queue.push([n, 0])
+  while (pointer < queue.length) {
+    const [position, time] = queue[pointer]
+    if (position === k) return time
+    queue.push([position - 1, time + 1])
+    queue.push([position + 1, time + 1])
+    queue.push([position * 2, time + 1])
+    pointer++
+  }
+}
+
+console.log(solution(N, K))

--- a/DFSBFS/BOJ_1697.js
+++ b/DFSBFS/BOJ_1697.js
@@ -1,3 +1,59 @@
+class Node {
+  constructor(position) {
+    this.position = position
+    this.previous = null
+    this.next = null
+  }
+}
+class Deque {
+  constructor() {
+    this.head = null
+    this.tail = null
+    this.size = 0
+  }
+  popFromLeft() {
+    if (this.head !== null) {
+      this.size -= 1
+      const popped = this.head
+      if (this.head === this.tail) {
+        //원소가 하나일 떄
+        this.head = null
+        this.tail = null
+        return popped.position
+      }
+      this.head = this.head.next
+      return popped.position
+    }
+  }
+  popFromRight() {
+    if (this.head !== null) {
+      this.size -= 1
+      const popped = this.tail
+      if (this.head === this.tail) {
+        //원소가 하나일 떄
+        this.head = null
+        this.tail = null
+        return popped
+      }
+      this.tail = this.tail.previous
+      this.tail.next = null
+      return popped.position
+    }
+  }
+  enqueue(position) {
+    this.size += 1
+    const node = new Node(position)
+    if (this.head === null) {
+      this.head = node
+      this.tail = node
+    } else {
+      this.tail.next = node
+      node.previous = this.tail
+      this.tail = node
+    }
+  }
+}
+
 const [N, K] = require('fs')
   .readFileSync(__dirname + '/test.txt')
   .toString()
@@ -8,29 +64,27 @@ const [N, K] = require('fs')
 const MAX = 100001
 const solution = (n, k) => {
   const table = new Array(MAX).fill(-1)
-  const queue = []
+  const queue = new Deque()
   table[n] = 0
-  queue.push(n)
-  let index = 0
-  while (index < queue.length) {
-    const popped = queue[index]
+  queue.enqueue(n)
+  while (queue.size >= 0) {
+    const popped = queue.popFromLeft()
     const time = table[popped]
     if (popped === k) {
       break
     }
     if (table[popped - 1] === -1 && popped - 1 >= 0) {
       table[popped - 1] = time + 1
-      queue.push(popped - 1)
+      queue.enqueue(popped - 1)
     }
     if (table[popped + 1] === -1 && popped + 1 < MAX) {
       table[popped + 1] = time + 1
-      queue.push(popped + 1)
+      queue.enqueue(popped + 1)
     }
     if (table[popped * 2] === -1 && popped * 2 < MAX) {
       table[popped * 2] = time + 1
-      queue.push(popped * 2)
+      queue.enqueue(popped * 2)
     }
-    index++
   }
   return table[k]
 }

--- a/DFSBFS/BOJ_1697.js
+++ b/DFSBFS/BOJ_1697.js
@@ -1,3 +1,60 @@
+class Node {
+  constructor(position, time) {
+    this.position = position
+    this.time = time
+    this.previous = null
+    this.next = null
+  }
+}
+class Deque {
+  constructor() {
+    this.head = null
+    this.tail = null
+    this.size = 0
+  }
+  popFromLeft() {
+    if (this.head !== null) {
+      this.size -= 1
+      const popped = this.head
+      if (this.head === this.tail) {
+        //원소가 하나일 떄
+        this.head = null
+        this.tail = null
+        return popped
+      }
+      this.head = this.head.next
+      return popped
+    }
+  }
+  popFromRight() {
+    if (this.head !== null) {
+      this.size -= 1
+      const popped = this.tail
+      if (this.head === this.tail) {
+        //원소가 하나일 떄
+        this.head = null
+        this.tail = null
+        return popped
+      }
+      this.tail = this.tail.previous
+      this.tail.next = null
+      return popped
+    }
+  }
+  enqueue(position, time) {
+    this.size += 1
+    const node = new Node(position, time)
+    if (this.head === null) {
+      this.head = node
+      this.tail = node
+    } else {
+      this.tail.next = node
+      node.previous = this.tail
+      this.tail = node
+    }
+  }
+}
+
 const [N, K] = require('fs')
   .readFileSync(__dirname + '/test.txt')
   .toString()
@@ -6,16 +63,14 @@ const [N, K] = require('fs')
   .map(Number)
 
 const solution = (n, k) => {
-  let pointer = 0
-  const queue = []
-  queue.push([n, 0])
-  while (pointer < queue.length) {
-    const [position, time] = queue[pointer]
-    if (position === k) return time
-    queue.push([position - 1, time + 1])
-    queue.push([position + 1, time + 1])
-    queue.push([position * 2, time + 1])
-    pointer++
+  const deque = new Deque()
+  deque.enqueue(n, 0)
+  while (deque.size >= 0) {
+    const poppedFromLeft = deque.popFromLeft()
+    if (poppedFromLeft.position === k) return poppedFromLeft.time
+    deque.enqueue(poppedFromLeft.position - 1, poppedFromLeft.time + 1)
+    deque.enqueue(poppedFromLeft.position + 1, poppedFromLeft.time + 1)
+    deque.enqueue(poppedFromLeft.position * 2, poppedFromLeft.time + 1)
   }
 }
 

--- a/DFSBFS/BOJ_1697.js
+++ b/DFSBFS/BOJ_1697.js
@@ -1,60 +1,3 @@
-class Node {
-  constructor(position, time) {
-    this.position = position
-    this.time = time
-    this.previous = null
-    this.next = null
-  }
-}
-class Deque {
-  constructor() {
-    this.head = null
-    this.tail = null
-    this.size = 0
-  }
-  popFromLeft() {
-    if (this.head !== null) {
-      this.size -= 1
-      const popped = this.head
-      if (this.head === this.tail) {
-        //원소가 하나일 떄
-        this.head = null
-        this.tail = null
-        return popped
-      }
-      this.head = this.head.next
-      return popped
-    }
-  }
-  popFromRight() {
-    if (this.head !== null) {
-      this.size -= 1
-      const popped = this.tail
-      if (this.head === this.tail) {
-        //원소가 하나일 떄
-        this.head = null
-        this.tail = null
-        return popped
-      }
-      this.tail = this.tail.previous
-      this.tail.next = null
-      return popped
-    }
-  }
-  enqueue(position, time) {
-    this.size += 1
-    const node = new Node(position, time)
-    if (this.head === null) {
-      this.head = node
-      this.tail = node
-    } else {
-      this.tail.next = node
-      node.previous = this.tail
-      this.tail = node
-    }
-  }
-}
-
 const [N, K] = require('fs')
   .readFileSync(__dirname + '/test.txt')
   .toString()
@@ -62,16 +5,34 @@ const [N, K] = require('fs')
   .split(' ')
   .map(Number)
 
+const MAX = 100001
 const solution = (n, k) => {
-  const deque = new Deque()
-  deque.enqueue(n, 0)
-  while (deque.size >= 0) {
-    const poppedFromLeft = deque.popFromLeft()
-    if (poppedFromLeft.position === k) return poppedFromLeft.time
-    deque.enqueue(poppedFromLeft.position - 1, poppedFromLeft.time + 1)
-    deque.enqueue(poppedFromLeft.position + 1, poppedFromLeft.time + 1)
-    deque.enqueue(poppedFromLeft.position * 2, poppedFromLeft.time + 1)
+  const table = new Array(MAX).fill(-1)
+  const queue = []
+  table[n] = 0
+  queue.push(n)
+  let index = 0
+  while (index < queue.length) {
+    const popped = queue[index]
+    const time = table[popped]
+    if (popped === k) {
+      break
+    }
+    if (table[popped - 1] === -1 && popped - 1 >= 0) {
+      table[popped - 1] = time + 1
+      queue.push(popped - 1)
+    }
+    if (table[popped + 1] === -1 && popped + 1 < MAX) {
+      table[popped + 1] = time + 1
+      queue.push(popped + 1)
+    }
+    if (table[popped * 2] === -1 && popped * 2 < MAX) {
+      table[popped * 2] = time + 1
+      queue.push(popped * 2)
+    }
+    index++
   }
+  return table[k]
 }
 
 console.log(solution(N, K))


### PR DESCRIPTION
# 문제: [숨바꼭질](https://www.acmicpc.net/problem/1697)
## 문제풀이 접근법
BFS + 방문 테이블
을 활용하여 문제를 풀었습니다.

## 구현 시 어려웠던 점
처음 풀이에서 메모리 초과가 났던 이유를 바로 떠올리지 못했습니다.
메모리 초과가 났던 이유는, 매번 3개씩의 원소를 배열에 추가하였기 때문입니다.

이렇게 진행할 경우, 메모리가 충분하다면 상관없겠지만, 그렇지 않은 경우에는 배열이 기하급수적으로 커지게 됩니다.

그래서 조건문을 통해 이미 방문했던 위치(이미 방문했다는 것은 최소한의 시간이 이미 기록되었다는 것)는 배열에 다시 넣지않는 것을 통해, 최대 큐의 길이가 100,000가 되도록 제한하였습니다.

## 깨달음
BFS/DFS라고해서 무조건적으로 큐/ 스택에 추가하는 것이 아니라, 적절한 조건을 통해 중복되는 케이스를 줄이는 방법이 유용하다는 것을 깨달았습니다.

## 실험

첫 문제해결에서는 `array.shift()`사용을 지양하기 위해 포인터를 사용했고, 
두 번째 문제해결에서는 Deque를 Node 클래스로 간단하게 구현하여 문제를 풀어보았는데,

포인터 사용이 코드 길이도 짧고, 메모리도 적게 차지하며, 시간 또한 적게 소요되었습니다.
![image](https://user-images.githubusercontent.com/44149596/153813337-35e5ec66-0425-4ae9-a006-419dcb9f695f.png)

