### PR TITLE
Add: 2022-02-15 전력망을 둘로나누기 문제해결

### DIFF
--- a/DFSBFS/PG_전력망.js
+++ b/DFSBFS/PG_전력망.js
@@ -1,0 +1,32 @@
+function solution(n, wires) {
+  let answer = n
+  for (let tobeRemoved = 0; tobeRemoved < wires.length; tobeRemoved++) {
+    const newWires = [...wires.slice(0, tobeRemoved), ...wires.slice(tobeRemoved + 1)]
+    //인접리스트로 그래프 작성
+    const graph = new Array(n + 1).fill(0).map((i) => [])
+    for (const connection of newWires) {
+      const [from, to] = connection
+      graph[from].push(to)
+      graph[to].push(from)
+    }
+    //BFS로 계산.
+    const visited = new Array(n + 1).fill(0)
+    const queue = []
+    queue.push(newWires[0][0])
+    visited[newWires[0][0]] = 1
+    let count = 1
+    while (queue.length) {
+      const from = queue.shift()
+      for (const to of graph[from]) {
+        if (visited[to] === 0) {
+          count++
+          visited[to] = 1
+          queue.push(to)
+        }
+      }
+    }
+    answer = Math.min(Math.max(count, n - count) - Math.min(count, n - count), answer)
+  }
+
+  return answer
+}


### PR DESCRIPTION
# 문제: [전력망을 둘로 나누기](https://programmers.co.kr/learn/courses/30/lessons/86971)
## 문제풀이 접근법
'트리' 구조의 특징을 이용한 BFS로 접근했습니다.
트리 구조에서는 한 edge를 제거하는 순간 트리가 두 부분으로 양분됩니다. 즉, 주어진 인자인 wires에서 임의의 1개의 edge를 뺀 순간 이미 그 트리는 2 부분으로 쪼개진 것입니다. 

따라서, wires에서 한 edge씩 빼가며 BFS를 진행하면 되겠습니다.

## 구현 시 어려웠던 점과 깨달음
- wires 를 그래프화 하는 방법을 선택하는 것 : 인접 행렬이냐 인접그래프 중에서, 메모리를 덜 차지하는 인접 그래프를 선택했습니다.
- 방문한 노드를 기록해야 한다는 발상