### PR TITLE
Add: 2022-02-16 농장관리 문제해결

### DIFF
--- a/DFSBFS/BOJ_1245.js
+++ b/DFSBFS/BOJ_1245.js
@@ -1,0 +1,64 @@
+const input = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+
+const [N, M] = input.shift().split(' ').map(Number)
+const graph = input.map((str) => str.split(' ').map(Number))
+
+const solution = () => {
+  let answer = 0
+  const dRow = [1, -1, 0, 0, 1, -1, 1, -1]
+  const dCol = [0, 0, 1, -1, 1, -1, -1, 1]
+  const visited = Array.from({ length: N }, () => Array.from({ length: M }, () => 0))
+  //각 좌표에서 봉우리가 생길 수 있는지를 검사
+  for (let row = 0; row < N; row++) {
+    for (let col = 0; col < M; col++) {
+      //이미 체크된 봉우리면 넘기기
+      if (visited[row][col] === 2) continue
+      const queue = []
+      queue.push([row, col])
+      let pointer = 0
+      const currHeight = graph[row][col]
+      visited[row][col] = 1
+      let isSummit = true
+      while (pointer < queue.length && isSummit) {
+        const [row, col] = queue[pointer]
+        for (let i = 0; i < 8; i++) {
+          const nextRow = row + dRow[i]
+          const nextCol = col + dCol[i]
+          if (
+            0 <= nextRow &&
+            nextRow < N &&
+            0 <= nextCol &&
+            nextCol < M &&
+            visited[nextRow][nextCol] !== 1
+          ) {
+            if (graph[nextRow][nextCol] > currHeight) {
+              isSummit = false
+            } else if (graph[nextRow][nextCol] === graph[row][col]) {
+              visited[nextRow][nextCol] = 1
+              queue.push([nextRow, nextCol])
+            }
+          }
+        }
+        pointer++
+      }
+      if (isSummit) {
+        answer++
+        //visit 에 2(봉우리)로서 체크하기
+        for (const summit of queue) {
+          visited[summit[0]][summit[1]] = 2
+        }
+      } else {
+        //다음 순회를 위해 1로 방문 처리되었던 visit 내 좌표들을 원상복구해준다.
+        for (const summit of queue) {
+          visited[summit[0]][summit[1]] = 0
+        }
+      }
+    }
+  }
+  return answer
+}
+console.log(solution())


### PR DESCRIPTION
# 문제: [농장관리](https://www.acmicpc.net/problem/1245)
## 문제풀이 접근법: 방문했던 곳을 기억했다가, 방문처리를 원상복귀 해주는 것이 핵심!
- 매 순회마다 봉우리 방문처리로 사용할 `visited`그래프를 작성합니다
- 각 좌표마다 BFS를 진행합니다.
  - 만약 해당 좌표가 이미 봉우리임이 검증된 좌표라면 다음 순회로 continue합니다.
  - 각 좌표 값을 봉우리라고 가정하고 visited를 1로 체크합니다. 
  - 봉우리값이 같은 경우에만 visited를 1로 체크하고 `queue`에 추가합니다.
  - 만약 탐색하는 좌표값이 한 번이라도 봉우리 값보다 큰 경우에는 해당 순회를 중지합니다. 이를 구현하기 위해 while 문에 `isSummit` 이라는 boolean 값을 함께 걸어주었습니다.
  - `isSummit`의 결과에 따라 visited를 원상복귀(0)하거나 봉우리임을 체크(2)합니다. 이를 위해서는 해당 순회에서 살펴봤던 봉우리 후보들의 목록이 필요합니다. 따라서 pointer를 활용하여 순회 종료 후, queue에서 살펴봤던 이전 데이터들이 잔류하도록 처리했습니다. shift() 를 사용하면 별도의 기록 배열을 사용해야 하기 때문에 shift()는 사용하지 않았습니다.

## 구현 시 어려웠던 점과 깨달음
- 봉우리값이 같은 경우에만 visited를 처리하고 큐에 집어넣는 발상
- BFS진행 후, 봉우리가 아니었을 경우에 방문 처리를 원상복귀하는 발상
  - 한 번 방문한 곳을 다시 방문하지 않는 여타 문제들과 다르게, 이 문제는 다음 순회에서 이전에 방문했었던 좌표를 다시 방문하여 검증해야 했습니다. 그렇지만 동시에, 이미 봉우리임이 검증되었던 곳들은 잔류토록 해야하는 문제가 있었습니다. 
  - 결국 봉우리임을 가정하여 BFS를 실행하고, 봉우리가 아닌 경우에는 원상 복귀를 시켜주는 것이 다음 순회에 영향을 주지 않는 방법임을 깨달았습니다.