### PR TITLE
Add: 2022-02-16 1로 만들기 문제해결

### DIFF
--- a/티어승급/BOJ_1463.js
+++ b/티어승급/BOJ_1463.js
@@ -1,0 +1,25 @@
+const N =
+  require('fs')
+    .readFileSync(__dirname + '/test.txt')
+    .toString()
+    .trim() * 1
+
+const solution = () => {
+  if (N === 1) console.log(0)
+  const arr = Array.from({ length: N + 1 }, () => N + 1)
+  arr[1] = 0
+  for (let i = 1; i < N + 1; i++) {
+    if (i + 1 < N + 1) {
+      arr[i + 1] = Math.min(arr[i + 1], arr[i] + 1)
+    }
+    if (i * 2 < N + 1) {
+      arr[i * 2] = Math.min(arr[i * 2], arr[i] + 1)
+    }
+    if (i * 3 < N + 1) {
+      arr[i * 3] = Math.min(arr[i * 3], arr[i] + 1)
+    }
+  }
+  return arr[N]
+}
+
+console.log(solution())


### PR DESCRIPTION
# 문제: [1로 만들기](https://www.acmicpc.net/problem/1463)
## 문제풀이 접근법
- N에서 1로 가는 방향으로, 큐를 통한 BFS로 접근하였으나 시간초과가 났습니다.
- 생각해보니 10의 6거듭제곱의 최악의 경우에는 큐를 사용하면 당연히 시간초과가 날 것입니다.
- 그렇다면 1에서 N까지 순회하며 DP 테이블을 갱신하는 방식으로 올라가면 어떨까? 라는 생각을 했습니다.
- 그 근거는 문제에서 1을 뺀다는 조건 때문이었습니다. 1을 뺀다는 것은 거꾸로 생각하면 이전 수보다 항상 1이 큰 수가 존재함을 보장하는 것이기 때문입니다.

## 구현 시 어려웠던 점과 깨달음
- 문제가 다이나믹 프로그래밍의 유형인지 깨닫는데 조금 시간이 걸렸습니다
- 문제의 설명이 너무 친절하여 그대로 구현하였더니 시간 초과가 났는데, 애초에 N의 크기를 고려했다면 큐를 이용한 BFS/DFS는 선택하지 않았을 것입니다. 
- 입력값이 매우 큰 경우에는 다이나믹 프로그래밍을 고려해 보는 것도 좋은 방법인 듯 합니다.


