### PR TITLE
Add: 2022-02-17 계단 오르기 문제해결

### DIFF
--- a/티어승급/BOJ_2579.js
+++ b/티어승급/BOJ_2579.js
@@ -1,0 +1,20 @@
+const inputArr = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+  .map(Number)
+
+const N = inputArr.shift()
+
+const solution = () => {
+  const dp = Array.from({ length: 3 }, () => Array.from({ length: N + 2 }, () => 0))
+  for (let index = 2; index < N + 2; index++) {
+    dp[0][index] = Math.max(dp[1][index - 1], dp[2][index - 1]) + inputArr[index - 2]
+    dp[1][index] = dp[0][index - 1]
+    dp[2][index] = dp[0][index - 2] + inputArr[index - 2]
+  }
+  return Math.max(dp[0][N + 1], dp[2][N + 1])
+}
+
+console.log(solution())


### PR DESCRIPTION
# 문제: [계단 오르기](https://www.acmicpc.net/problem/2579)
## 문제풀이 접근법
- DP 로 접근했습니다.
- 첫 문제풀이 (중구난방...)
<img src="https://user-images.githubusercontent.com/44149596/154416214-817fe883-a865-49f3-be40-5a79fac022a8.png" width:500/>
- 두 번째 문제풀이 (정리버전)
<img src="https://user-images.githubusercontent.com/44149596/154417860-0be95332-db90-4983-a400-6afcf038b39a.png" width:500/>

문제의 핵심은 현재 내가 딛고 있는 계단을 선택했을 때와 선택하지 않았을 때의 최대값이 달라진다는 것을 인지하는 것이었습니다. 

그리고 해당 계단을 선택하는 것을 결정했을 때, 연속으로 3개 이상의 계단은 밟지 못한다는 제약사항이 걸려있음을 인지하고, 해당 계단이 선택될 수 있는 조건을 분기해야겠다는 생각이 들었습니다.

해당 계단인 i 번째 계단을 선택했을 때 최대값을 구할 수 있는 경우는 다음과 같았습니다
- i 번째 계단을 선택 안했을 시 최대값, i-1번째 계단을 선택하지 않고(i-2번째 계단을 선택했을 시의 최대값) 중 큰 값 + i 번째 계단의 값

- i 번째 계단을 선택 안했을 시의 최대값은 i-1번째 계단을 선택했을 시의 최대값임을 발견했습니다
- i -1 번째 선택을 안하고 i 번째 계단을 선택하는 최대값은 i-2번째 계단을 선택했을 시의 최대값 + i 번째 계단의 값임을 발견했습니다.

이렇게 보니 세 가지 종류의 값을 저장하는 테이블을 만들어야겠다는 생각을 하였습니다.
그래서 3* n+2 크기의 테이블을 만들어 위에서 발견한 규칙에 따라 테이블을 채웠습니다.

테이블을 다 채운 후, 결과를 도출할 때는 테이블의 마지막 컬럼에서 계단을 선택하는 두 가지 케이스 중 max값을 반환했습니다. 왜냐하면 문제에서 마지막 계단은 반드시 밟아야 한다고 명시했기 때문입니다.

## 구현 시 어려웠던 점과 깨달음
- 테이블을 작성하면서 과거 시점의 수행 결과를 현재 시점의 수행과 연관지어서 규칙을 찾는 것이 어려웠습니다.
- i-1번째 계단 선택하지 않고 i 번째 계단을 선택하는 최대값을 구할 때, 초기 풀이에서는 i-2번쨰 컬럼의 값들 중 최대값을 가지고 테이블을 작성했으나, 이내 잘못됨을 깨달았습니다. i-1번째 계단을 선택하지 않는 경우 중, i 번째 계단을 선택하도록 하는 최적의 선택은 i-2번째 계단을 밟을 때의 최대값이기 때문입니다.
- 마지막 계단을 반드시 밟아야 한다는 조건을 간과한 채로 결과를 도출하여 잘못된 결과를 도출했었습니다. 문제의 조건을 잘 따져서 구현하는 것이 중요하다는 깨달음을 얻었습니다.

