### PR TITLE
Add:2022-02-23  오큰수 문제해결

### DIFF
--- a/스택큐/BOJ_17298.js
+++ b/스택큐/BOJ_17298.js
@@ -1,0 +1,22 @@
+const input = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+
+const N = input.shift() * 1
+const arr = input[0].split(' ').map(Number)
+
+const solution = () => {
+  const result = Array.from({ length: N }, () => -1)
+  const stack = []
+  for (let i = 0; i < N; i++) {
+    while (stack.length && arr[stack[stack.length - 1]] < arr[i]) {
+      const poppedIndex = stack.pop()
+      result[poppedIndex] = arr[i]
+    }
+    stack.push(i)
+  }
+  return result.join(' ')
+}
+console.log(solution())


### PR DESCRIPTION
# 문제: [오큰수](https://www.acmicpc.net/problem/17298)
## 문제풀이 접근법
- 스택에 인덱스를 기록
- 결과 배열에는 순회 시점의 수를 기록
![IMG_C7CE653F8700-1](https://user-images.githubusercontent.com/44149596/155237469-9035121f-c4e3-4587-9039-65a5a2cb14c5.jpeg)

## 구현 시 어려웠던 점과 깨달음
- 스택에 분명히 TOP 보다 큰 수를 기억해야 한다는 것은 알았지만, 원하는 답을 도출하는 시점을 어떻게 잡아야 할 지 고민했습니다.
- 스택에 넣을 때, 또는 뺄 때, 또는 결과로 남았을 때. 이 셋 중 하나가 원하는 답 중 하나인데, 이 문제에서는 스택에서 뺄 때가 정답을 기록하는 시점이었습니다

