### PR TITLE
Refactor: 최대값 로직 수정

### DIFF
--- a/BOJ_Silver2/BOJ_1912.js
+++ b/BOJ_Silver2/BOJ_1912.js
@@ -7,7 +7,7 @@ const solution = () => {
   const dp = Array.from({ length: N }, () => 0)
   dp[0] = arr[0]
   for (let i = 1; i < N; i++) {
-    dp[i] = Math.max(Math.max(arr[i - 1], dp[i - 1]), 0) + arr[i]
+    dp[i] = Math.max(dp[i - 1], 0) + arr[i]
   }
   return Math.max(...dp)
 }


### PR DESCRIPTION
# 문제: [연속합](https://www.acmicpc.net/problem/1912)
## 문제풀이 접근법
- DP
- 입력 크기가 100,000이었으며, 연속된 합을 쌓는 방식의 순차적 접근이라는 문제의 특성을 통해 완전탐색이 아닌 DP 임을 직감하였습니다.
- dp[i]라는 것이 "i번째 인덱스의 값까지 dp를 진행했을 때의 최대값"이라면, dp[i] 번째 값을 결정하는 방법 총 세 가지가 있습니다.
  - dp[i-1]의 값에 더함으로써 (i-1 까지 진행했을 때의 최대값)
  - 이전 값과는 상관없이 arr[i]부터 새로이 시작하는 방법
수를 연속적으로 쌓아가는 것이기 때문에, 이 중 최대값을 선택하면 됩니다.

이 과정을 그림으로 보면 다음과 같습니다.
![IMG_3149A9F2ACBF-1](https://user-images.githubusercontent.com/44149596/155467765-7bb30584-d468-4568-ac14-be3839d0fb03.jpeg)

## 구현 시 어려웠던 점과 깨달음
- 문제의 접근법을 다이나믹 프로그래밍으로 결정하는 것이 어려웠습니다. 얼핏 보면 배열에서 1개부터 n개의 수를 뽑아가며 완전탐색을 해야겠지만, 이 방법의 시간 복잡도는 매우 높기 때문에, 주어진 입력과 시간 내에서 수행할 수 없음을 깨달았습니다.


