### PR TITLE
Add: 2022-02-24 연결 요소의 개수 문제해결

### DIFF
--- a/BOJ_Silver2/BOJ_11724.js
+++ b/BOJ_Silver2/BOJ_11724.js
@@ -1,0 +1,36 @@
+const input = require('fs')
+  .readFileSync(__dirname + '/test.txt')
+  .toString()
+  .trim()
+  .split('\n')
+
+const [N, M] = input.shift().split(' ').map(Number)
+
+const solution = () => {
+  const DFS = (start) => {
+    visited[start] = 1
+    for (const target of adjList[start]) {
+      if (visited[target]) continue
+      DFS(target)
+    }
+  }
+
+  //인접리스트를 통한 BFS 또는 DFS
+  let answer = 0
+  const adjList = Array.from({ length: N + 1 }, () => [])
+  const visited = Array.from({ length: N + 1 }, () => 0)
+  for (let i = 0; i < input.length; i++) {
+    const [u, v] = input[i].split(' ').map(Number)
+    adjList[u].push(v)
+    adjList[v].push(u)
+  }
+  //각 정점에서 탐색을 시작하며,정점이 방문이 안되었을 때만 탐색한다.
+  for (let i = 1; i < N + 1; i++) {
+    if (visited[i]) continue
+    DFS(i)
+    answer += 1
+  }
+  return answer
+}
+
+console.log(solution())


### PR DESCRIPTION
# 문제: [연결 요소의 개수](https://www.acmicpc.net/problem/11724)
## 문제풀이 접근법
연결된 덩어리가 몇 개인지 찾는 문제였습니다.
이 덩어리는 DFS/BFS를 아직 방문되지 않은 각 정점에서 시작함으로써 파악할 수 있습니다.
![image](https://user-images.githubusercontent.com/44149596/155478699-d808c053-6f12-4bae-8cf9-b0e2184caed7.png)


## 구현 시 어려웠던 점과 깨달음
- 항상 DFS를 재귀로 구성하는 것은 쉽지 않습니다. 재귀에 대한 연습이 더욱 필요해 보입니다.
- 자바스크립트에서는 큐가 구현이 되어있지 않기 때문에, BFS,DFS 둘 다 통용되는 문제라면 DFS를 사용하는 편이 더욱 구현하기 편하기 때문입니다.


